### PR TITLE
Make contributor email example configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,6 @@ All notable changes to this service will be documented in this file.
 ## [1.3.11]
 ### Notes
 - Added site-wide notification banner and feature flag
-- Set Entra SSO enabled to false
 
 ## [1.3.12]
 ### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,7 @@ All notable changes to this service will be documented in this file.
 ## [1.3.10]
 ### Notes
 - Set Entra SSO enabled to false
+
+## [1.3.11]
+### Notes
+- Make email address configurable on invite a contributor page

--- a/src/DfE.ExternalApplications.Web/DfE.ExternalApplications.Web.csproj
+++ b/src/DfE.ExternalApplications.Web/DfE.ExternalApplications.Web.csproj
@@ -5,8 +5,8 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>8051c984-585b-4a5e-b6d7-833e5dd4afe7</UserSecretsId>
-		<Version>1.3.10</Version>
-		<InformationalVersion>1.3.10</InformationalVersion>
+		<Version>1.3.11</Version>
+		<InformationalVersion>1.3.11</InformationalVersion>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 	</PropertyGroup>
 

--- a/src/DfE.ExternalApplications.Web/Pages/Applications/Contributors.cshtml
+++ b/src/DfE.ExternalApplications.Web/Pages/Applications/Contributors.cshtml
@@ -1,6 +1,8 @@
 @page "/applications/{referenceNumber}/contributors"
 @using DfE.ExternalApplications.Web.Extensions
 @model ContributorsModel
+@inject IConfiguration Configuration
+
 @{
     ViewData["Title"] = "Invite contributors";
 
@@ -33,7 +35,7 @@
         </p>
 
         <p class="govuk-body">
-            They must have a DfE Sign-in account. They can only create an account using a business email address with their name. For example, firstname.lastname@schooldomain.
+            They must have a DfE Sign-in account. They can only create an account using a business email address with their name. For example, @Configuration["Layout:ContributorEmail"].
         </p>
 
         <p class="govuk-body">

--- a/src/DfE.ExternalApplications.Web/configurations/Lsrp/appsettings.json
+++ b/src/DfE.ExternalApplications.Web/configurations/Lsrp/appsettings.json
@@ -124,7 +124,8 @@
     "PhaseBanner": {
       "PhaseText": "Alpha",
       "FeedbackLink": "/Feedback"
-    }
+    },
+    "ContributorEmail": "firstname.lastname@organisationdomain"
   },
   "Template": {
     "Id": "B2F8E7D4-2C46-4A91-8E73-9D5A1F4B6C89",

--- a/src/DfE.ExternalApplications.Web/configurations/Transfers/appsettings.json
+++ b/src/DfE.ExternalApplications.Web/configurations/Transfers/appsettings.json
@@ -130,7 +130,8 @@
     "PhaseBanner": {
       "PhaseText": "Beta",
       "FeedbackLink": "/Feedback"
-    }
+    },
+    "ContributorEmail": "firstname.lastname@schooldomain"
   },
   "Template": {
     "Id": "9A4E9C58-9135-468C-B154-7B966F7ACFB7",


### PR DESCRIPTION
This change needs to be tested in development, as my local dev environment is not up and running yet.

User Story 270936: Build: Make email address configurable on invite a contributor page
