### PR TITLE
make lead applicant label configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,3 +127,7 @@ All notable changes to this service will be documented in this file.
 ## [1.3.14]
 ### Notes
 - Remove the word "form" from the plan version label
+
+## [1.3.15]
+### Notes
+- Make the lead applicant label configurable in form header

--- a/src/DfE.ExternalApplications.Web/DfE.ExternalApplications.Web.csproj
+++ b/src/DfE.ExternalApplications.Web/DfE.ExternalApplications.Web.csproj
@@ -5,8 +5,8 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>8051c984-585b-4a5e-b6d7-833e5dd4afe7</UserSecretsId>
-		<Version>1.3.14</Version>
-		<InformationalVersion>1.3.14</InformationalVersion>
+		<Version>1.3.15</Version>
+		<InformationalVersion>1.3.15</InformationalVersion>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 	</PropertyGroup>
 

--- a/src/DfE.ExternalApplications.Web/Views/Shared/FormEngine/_FormHeader.cshtml
+++ b/src/DfE.ExternalApplications.Web/Views/Shared/FormEngine/_FormHeader.cshtml
@@ -1,4 +1,6 @@
 @model DfE.ExternalApplications.Web.Pages.FormEngine.RenderFormModel
+@inject IConfiguration Configuration
+
 @{
     var applicationId = Context.Session.GetString("ApplicationId");
     var leadApplicantName = Context.Session.GetString($"ApplicationLeadApplicantName_{applicationId}");
@@ -9,5 +11,5 @@
 <div class="govuk-!-margin-bottom-6" style="border-left: 4px solid #b1b4b6; padding-left: 15px;">
     <p class="govuk-body govuk-!-margin-bottom-1">@AppTerminology.SingularCapitalised reference: <strong>@Model.ReferenceNumber</strong></p>
     <p class="govuk-body govuk-!-margin-bottom-0">@AppTerminology.SingularCapitalised form version: <strong>@applicationFormVersion</strong></p>
-    <p class="govuk-body govuk-!-margin-bottom-0">Lead applicant: <strong>@leadApplicantName</strong></p>
+    <p class="govuk-body govuk-!-margin-bottom-0">@Configuration["Layout:LeadApplicant"]: <strong>@leadApplicantName</strong></p>
 </div>

--- a/src/DfE.ExternalApplications.Web/configurations/Lsrp/appsettings.json
+++ b/src/DfE.ExternalApplications.Web/configurations/Lsrp/appsettings.json
@@ -130,7 +130,8 @@
       "PhaseText": "Alpha",
       "FeedbackLink": "/Feedback"
     },
-    "ContributorEmail": "firstname.lastname@organisationdomain"
+    "ContributorEmail": "firstname.lastname@organisationdomain",
+    "LeadApplicant": "Senior Responsible Officer"
   },
   "Template": {
     "Id": "B2F8E7D4-2C46-4A91-8E73-9D5A1F4B6C89",

--- a/src/DfE.ExternalApplications.Web/configurations/Transfers/appsettings.json
+++ b/src/DfE.ExternalApplications.Web/configurations/Transfers/appsettings.json
@@ -136,7 +136,8 @@
       "PhaseText": "Beta",
       "FeedbackLink": "/Feedback"
     },
-    "ContributorEmail": "firstname.lastname@schooldomain"
+    "ContributorEmail": "firstname.lastname@schooldomain",
+    "LeadApplicant": "Lead applicant"
   },
   "Template": {
     "Id": "9A4E9C58-9135-468C-B154-7B966F7ACFB7",


### PR DESCRIPTION
User Story 274605: Build: Task list page - make "lead applicant" label configurable per service

NOTE the change log and app version will need to be updated once my other two pull requests have been merged